### PR TITLE
fix async bug in hook-require

### DIFF
--- a/index.ls
+++ b/index.ls
@@ -95,7 +95,7 @@ module.exports = ->
             (file, encoding, callback) ->
                 delete require.cache[path.resolve file.path]
                 callback null, file
-            ->
+            (callback) !->
                 hook.unhook-require!
                 
                 # hook-require :: (String -> Boolean) -> (String -> String -> String) -> object -> ?
@@ -103,6 +103,7 @@ module.exports = ->
                     (path) -> !!(instrument-code path)
                     (code, path) -> (instrument-code path).instrumented-code
                     extensions: <[.js .ls]>
+                callback!
 
     # must be called after running unit tests
     # ReportName :: String

--- a/test/index.ls
+++ b/test/index.ls
@@ -7,6 +7,7 @@ require! \gulp-util
 gulp-livescript-istanbul = (require \../index)
 require! \path
 require! \rimraf
+through = (require! \through2).obj
 
 describe "gulp-livescript-istanbul", ->
 
@@ -38,6 +39,15 @@ describe "gulp-livescript-istanbul", ->
                     add-after-hook = require \./fixtures/calculator
                     assert.not-equal add-before-hook, add-after-hook
                     done!
+            stream.write @test-file
+            stream.end!
+
+        specify "must forward its finish event", (done) ->
+            {hook-require} = gulp-livescript-istanbul!
+            stream = hook-require!
+                ..pipe through do
+                    (f, e, callback) -> callback!
+                    -> done!
             stream.write @test-file
             stream.end!
 


### PR DESCRIPTION
Both the transform and flush functions passed to a through stream need to
call their callback arguments, or the through stream won't forward its
finish event correctly.
